### PR TITLE
Add basic plugin implementations

### DIFF
--- a/src/dumbo/__init__.py
+++ b/src/dumbo/__init__.py
@@ -5,7 +5,15 @@ from simple_parsing import field as simple_field, parse as simple_parse
 
 from .result import Result, Ok, is_err
 from .logger import setup_root, get_logger
-from .plugin_loader import import_plugin
+from .plugin_loader import (
+    import_plugin,
+    ModelLoaderPlugin,
+    TokenizerLoaderPlugin,
+    ModelPatcherPlugin,
+    DatasetLoaderPlugin,
+    DatasetFormatterPlugin,
+    TrainerPlugin,
+)
 
 logger = get_logger()
 
@@ -21,14 +29,59 @@ def main(args: Args) -> Result[None]:
     logger.info("Config loaded successfully")
 
     logger.info("Loading plugins...")
-    plugins = {}
+    plugin_instances = []
 
     for plugin_name in config["plugins"]:
         plugin_result = import_plugin(plugin_name)
         if is_err(plugin_result):
             return plugin_result
-        plugins[plugin_name] = plugin_result.unwrap()
+        plugin_instances.extend(plugin_result.unwrap())
     logger.info("Plugins loaded successfully")
+
+    model = None
+    tokenizer = None
+    dataset = None
+
+    for plugin in plugin_instances:
+        if isinstance(plugin, ModelLoaderPlugin):
+            result = plugin.load_model(config.get("model", {}))
+            if is_err(result):
+                return result
+            model = result.unwrap()
+
+    for plugin in plugin_instances:
+        if isinstance(plugin, TokenizerLoaderPlugin):
+            result = plugin.load_tokenizer(config.get("model", {}))
+            if is_err(result):
+                return result
+            tokenizer = result.unwrap()
+
+    for plugin in plugin_instances:
+        if isinstance(plugin, ModelPatcherPlugin) and model is not None:
+            result = plugin.patch_model(model, config.get(plugin.config_key))
+            if is_err(result):
+                return result
+            model = result.unwrap()
+
+    for plugin in plugin_instances:
+        if isinstance(plugin, DatasetLoaderPlugin):
+            result = plugin.load_dataset(config.get("datasets", []))
+            if is_err(result):
+                return result
+            dataset = result.unwrap()
+
+    for plugin in plugin_instances:
+        if isinstance(plugin, DatasetFormatterPlugin) and dataset is not None:
+            result = plugin.format_dataset(dataset, config.get("datasets", []))
+            if is_err(result):
+                return result
+            dataset = result.unwrap()
+
+    for plugin in plugin_instances:
+        if isinstance(plugin, TrainerPlugin):
+            result = plugin.train(model, tokenizer, dataset, config.get("trl", {}))
+            if is_err(result):
+                return result
 
     return Ok(None)
 

--- a/src/dumbo/__main__.py
+++ b/src/dumbo/__main__.py
@@ -1,0 +1,5 @@
+from . import real_main
+
+if __name__ == "__main__":
+    real_main()
+

--- a/src/dumbo/plugins/jinja_formatter.py
+++ b/src/dumbo/plugins/jinja_formatter.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Callable, List, TYPE_CHECKING
+
+try:
+    import polars as pl
+except Exception:  # pragma: no cover - optional dependency
+    pl = None  # type: ignore
+if TYPE_CHECKING:
+    import polars as pl  # type: ignore
+
+try:
+    from jinja2 import Template
+except Exception:  # pragma: no cover - optional dependency
+    Template = None  # type: ignore
+
+from dumbo.logger import get_logger
+from dumbo.plugin_loader import DatasetFormatterPlugin
+from dumbo.result import Ok, Err, Result
+
+logger = get_logger()
+
+
+class JinjaFormatterPlugin(DatasetFormatterPlugin):
+    """Apply a Jinja template to each dataset row."""
+
+    def format_dataset(self, dataset: Any, config: List[dict[str, Any]]) -> Result[Any]:
+        if pl is None or Template is None:
+            logger.error("Required dependencies for JinjaFormatter are missing")
+            return Err(ImportError("polars or jinja2 not installed"))
+        if not dataset.shape[0]:
+            return Ok(dataset)
+        fmt = config[0].get("train_format", {})
+        template_str = fmt.get("template", "{{ messages }}")
+        template = Template(template_str)
+        logger.info("Formatting dataset with Jinja template...")
+        rendered = [template.render(messages=row[0]) for row in dataset.select("messages").iter_rows()]
+        df = dataset.with_columns(pl.Series("text", rendered))
+        return Ok(df)
+
+AVAILABLE_PLUGINS = [JinjaFormatterPlugin]
+

--- a/src/dumbo/plugins/liger.py
+++ b/src/dumbo/plugins/liger.py
@@ -1,23 +1,33 @@
-from dumbo.plugin_loader import BasePlugin
-from dumbo.result import Result
 from typing import Any, Callable
-from transformers import AutoModelForCausalLM
+
 from dumbo.logger import get_logger
+from dumbo.plugin_loader import BasePlugin, Model
+from dumbo.result import Ok, Result
 
 logger = get_logger()
 
-from liger_kernel.transformers.monkey_patch import _apply_liger_kernel_to_instance
+try:
+    from liger_kernel.transformers.monkey_patch import _apply_liger_kernel_to_instance
+except Exception:  # pragma: no cover - optional dependency
+    _apply_liger_kernel_to_instance = None  # type: ignore
+
 
 class LigerPlugin(BasePlugin):
     config_key = "liger"
     requires = ["transformers_model"]
-    
+
     def hooks(self) -> dict[str, Callable]:
         return {
             "model_patcher": self.patch_model,
         }
-    
-    def patch_model(self, model: AutoModelForCausalLM, config: dict[str, Any] | None) -> Result[AutoModelForCausalLM]:
+
+    def patch_model(self, model: Model, config: dict[str, Any] | None) -> Result[Model]:
         logger.info("Patching model...")
-        _apply_liger_kernel_to_instance(model, **config)
+        if _apply_liger_kernel_to_instance is None:
+            logger.warning("liger-kernel not installed; skipping patch")
+            return Ok(model)
+        _apply_liger_kernel_to_instance(model, **(config or {}))
         return Ok(model)
+
+AVAILABLE_PLUGINS = [LigerPlugin]
+

--- a/src/dumbo/plugins/polars.py
+++ b/src/dumbo/plugins/polars.py
@@ -1,0 +1,69 @@
+from typing import Any, List
+
+try:
+    import polars as pl
+except Exception:  # pragma: no cover - optional dependency
+    pl = None  # type: ignore
+
+try:
+    from datasets import load_dataset
+except Exception:  # pragma: no cover - optional dependency
+    load_dataset = None  # type: ignore
+
+from dumbo.logger import get_logger
+from dumbo.plugin_loader import DatasetLoaderPlugin
+from dumbo.result import Ok, Err, Result
+
+logger = get_logger()
+
+
+class PolarsDatasetPlugin(DatasetLoaderPlugin):
+    """Load datasets using Polars and optionally the 🤗 *datasets* library."""
+
+    def load_dataset(self, config: List[dict[str, Any]]) -> Result[Any]:
+        if pl is None:
+            logger.error("polars is not installed")
+            return Err(ImportError("polars is not installed"))
+
+        cfg = config[0] if config else {}
+        ds_type = cfg.get("type", "huggingface_polars")
+        path = cfg.get("path")
+
+        logger.info(f"Loading dataset type '{ds_type}' from {path}...")
+
+        try:
+            if ds_type == "huggingface_polars":
+                if load_dataset is None:
+                    raise ImportError("datasets library is not installed")
+                dataset = load_dataset(path, split="train[:100]")
+                df = pl.from_pandas(dataset.to_pandas())
+            elif ds_type == "csv_polars":
+                df = pl.read_csv(path)
+            elif ds_type == "json_polars":
+                df = pl.read_json(path)
+            elif ds_type == "parquet_polars":
+                df = pl.read_parquet(path)
+            else:
+                raise ValueError(f"Unsupported dataset type: {ds_type}")
+
+            if cfg.get("data_format") == "alpaca":
+                logger.info("Converting Alpaca format to messages list...")
+                df = df.with_columns(
+                    pl.struct(["instruction", "input", "output"]).map_elements(
+                        lambda row: [
+                            {
+                                "role": "user",
+                                "content": f"{row['instruction']}\n{row['input']}".strip(),
+                            },
+                            {"role": "assistant", "content": row["output"]},
+                        ]
+                    ).alias("messages")
+                ).select("messages")
+
+            return Ok(df)
+        except Exception as e:  # pragma: no cover - runtime failures
+            logger.error(f"Failed to load dataset: {e}")
+            return Err(e)
+
+AVAILABLE_PLUGINS = [PolarsDatasetPlugin]
+

--- a/src/dumbo/plugins/transformers.py
+++ b/src/dumbo/plugins/transformers.py
@@ -1,9 +1,19 @@
-from transformers import AutoModelForCausalLM, AutoTokenizer
-from dumbo.result import Result, Ok
-from dumbo.plugin_loader import ModelLoaderPlugin, TokenizerLoaderPlugin
-from dumbo.plugin_loader import Model, Tokenizer
 from typing import Any
+
 from dumbo.logger import get_logger
+from dumbo.plugin_loader import (
+    Model,
+    ModelLoaderPlugin,
+    Tokenizer,
+    TokenizerLoaderPlugin,
+)
+from dumbo.result import Ok, Err, Result
+
+try:  # heavy dependency; import lazily if available
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+except Exception:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None  # type: ignore
+    AutoTokenizer = None  # type: ignore
 
 logger = get_logger()
 
@@ -12,9 +22,20 @@ class TransformersModelLoaderPlugin(ModelLoaderPlugin):
 
     def load_model(self, config: dict[str, Any]) -> Result[Model]:
         logger.info(f"Loading model from {config['base_model']}...")
-        model = AutoModelForCausalLM.from_pretrained(config["base_model"])
-        logger.info("Model loaded successfully")
-        return Ok(model)
+        if AutoModelForCausalLM is None:
+            logger.error("transformers is not installed")
+            return Err(ImportError("transformers is not installed"))
+
+        try:
+            model = AutoModelForCausalLM.from_pretrained(
+                config["base_model"],
+                device_map="auto",
+            )
+            logger.info("Model loaded successfully")
+            return Ok(model)
+        except Exception as e:  # pragma: no cover - runtime failures
+            logger.error(f"Failed to load model: {e}")
+            return Err(e)
 
 
 class TransformersTokenizerLoaderPlugin(TokenizerLoaderPlugin):
@@ -22,10 +43,19 @@ class TransformersTokenizerLoaderPlugin(TokenizerLoaderPlugin):
 
     def load_tokenizer(self, config: dict[str, Any]) -> Result[Tokenizer]:
         logger.info(f"Loading tokenizer from {config['base_model']}...")
-        tokenizer = AutoTokenizer.from_pretrained(config["base_model"])
-        return Ok(tokenizer)
+        if AutoTokenizer is None:
+            logger.error("transformers is not installed")
+            return Err(ImportError("transformers is not installed"))
+
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(config["base_model"])
+            return Ok(tokenizer)
+        except Exception as e:  # pragma: no cover - runtime failures
+            logger.error(f"Failed to load tokenizer: {e}")
+            return Err(e)
 
 AVAILABLE_PLUGINS = [
     TransformersModelLoaderPlugin,
     TransformersTokenizerLoaderPlugin,
 ]
+

--- a/src/dumbo/plugins/trl.py
+++ b/src/dumbo/plugins/trl.py
@@ -1,0 +1,62 @@
+from typing import Any, Callable
+
+from dumbo.logger import get_logger
+from dumbo.plugin_loader import TrainerPlugin, Model, Tokenizer
+from dumbo.result import Ok, Err, Result
+
+try:
+    from trl import SFTTrainer
+    from transformers import TrainingArguments
+    from datasets import Dataset
+except Exception:  # pragma: no cover - optional dependency
+    SFTTrainer = None  # type: ignore
+    TrainingArguments = None  # type: ignore
+    Dataset = None  # type: ignore
+
+logger = get_logger()
+
+
+class TRLPlugin(TrainerPlugin):
+    """Train the model with `trl`'s SFT trainer if available."""
+
+    def train(
+        self,
+        model: Model,
+        tokenizer: Tokenizer,
+        dataset: Any,
+        config: dict[str, Any],
+    ) -> Result[None]:
+        if SFTTrainer is None or TrainingArguments is None or Dataset is None:
+            logger.error("trl or transformers is not installed; skipping training")
+            return Err(ImportError("trl or transformers not available"))
+
+        if model is None or tokenizer is None or dataset is None:
+            return Err(ValueError("model, tokenizer and dataset must not be None"))
+
+        try:
+            logger.info("Starting training with TRL...")
+            args_cfg = config.get("arguments", {})
+            training_args = TrainingArguments(
+                output_dir="./outputs",
+                num_train_epochs=1,
+                **args_cfg,
+            )
+
+            if not isinstance(dataset, Dataset):
+                dataset = Dataset.from_pandas(dataset.to_pandas())
+
+            trainer = SFTTrainer(
+                model=model,
+                train_dataset=dataset,
+                tokenizer=tokenizer,
+                args=training_args,
+            )
+            trainer.train()
+            logger.info("Training completed")
+            return Ok(None)
+        except Exception as e:  # pragma: no cover - runtime failures
+            logger.error(f"Training failed: {e}")
+            return Err(e)
+
+AVAILABLE_PLUGINS = [TRLPlugin]
+


### PR DESCRIPTION
## Summary
- make polars dataset loader actually read HuggingFace or local files
- guard jinja formatter and dataset loader against missing dependencies
- load transformers models/tokenizers with proper error handling
- wire up TRL training with SFTTrainer when available

## Testing
- `PYTHONPATH=src python -m dumbo examples/smollm/small.yaml` *(fails: requires PyTorch)*

------
https://chatgpt.com/codex/tasks/task_e_6864b21ed150832fa513d75956309852